### PR TITLE
feat: fix the bug that custom db_class alters global metadata state

### DIFF
--- a/sqlalchemy_adapter/adapter.py
+++ b/sqlalchemy_adapter/adapter.py
@@ -88,6 +88,7 @@ class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
 
         if db_class is None:
             db_class = create_casbin_rule_class(table_name=table_name)
+            metadata = Base.metadata
         else:
             for attr in (
                 "id",
@@ -101,12 +102,12 @@ class Adapter(persist.Adapter, persist.adapters.UpdateAdapter):
             ):  # id attr was used by filter
                 if not hasattr(db_class, attr):
                     raise Exception(f"{attr} not found in custom DatabaseClass.")
-            Base.metadata = db_class.metadata
+            metadata = db_class.metadata
 
         self._db_class = db_class
         self.session_local = sessionmaker(bind=self._engine)
 
-        Base.metadata.create_all(self._engine)
+        metadata.create_all(self._engine)
         self._filtered = filtered
 
     @contextmanager


### PR DESCRIPTION
Fix: https://github.com/officialpycasbin/sqlalchemy-adapter/issues/2

fix: fix the bug that custom db_class alters global metadata state #2 

### Short Description
When creating multiple adapters in sequence, the first adapter using CustomCasbinRule will change the state of global Base.metadata. The subsequent adapters that do not use CustomCasbinRule will also be affected, and the schema of the created data tables will be incorrect.
`casbin_sqlalchemy_adapter.Adapter(ENGINE, db_class=CustomCasbinRule)`
`casbin_sqlalchemy_adapter.Adapter(ENGINE)`

### Root Cause
The following code exists in the adapter.py file: 
`if db_class is None:`
`    db_class = create_casbin_rule_class(table_name=table_name)`
`else:`
`    ...`
`    Base.metadata = db_class.metadata`
`...`
`Base.metadata.create_all(self._engine)`

When db_class is not None, Base.metadata will be modified. When db_class is None, the program still uses the modified Base.metadata to create the data tables, which results in the newly created tables having incorrect schema parameters.

### Solution of this PR
When creating the data table, do not use the global Base.metadata data but store the metadata on the instance of the Adapter instead.


